### PR TITLE
Exclusao do Funcionario V2

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,5 +8,5 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_23" default="true" project-jdk-name="23" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="23" project-jdk-type="JavaSDK" />
 </project>

--- a/src/main/java/com/dove/entities/PedidoEntity.java
+++ b/src/main/java/com/dove/entities/PedidoEntity.java
@@ -25,7 +25,7 @@ public class PedidoEntity {
     @JoinColumn(name = "cardapio_id", nullable = false)
     private CardapiosEntity cardapio;
     @ManyToOne
-    @JoinColumn(name = "funcionario_id")
+    @JoinColumn(name = "funcionario_id", nullable = false)
     private FuncionarioEntity funcionario;
     @ManyToOne
     @JoinColumn(name = "cliente_id")


### PR DESCRIPTION

Corrigi o problema que permitia excluir um funcionário mesmo quando ele ainda estava vinculado a algum pedido. Agora, antes de remover, o sistema verifica se existe algum pedido relacionado e bloqueia a exclusão caso tenha, garantindo que não fique nenhum pedido sem funcionário.